### PR TITLE
fix: Load vite env vars in production

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,3 @@
+VITE_API_BASE=http://localhost:3002
+VITE_BACKEND_WSS_URL=ws://localhost:3001/
+VITE_UMS_URL=http://localhost:3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ FROM    base AS build
 WORKDIR /app
 COPY    --from=deps /deps/dev/node_modules ./node_modules
 COPY    . .
+COPY    .env.production .
 
 ENV     NODE_ENV production
 RUN     npm run build


### PR DESCRIPTION
Necessary to allow vite to access env vars when running in Docker